### PR TITLE
Fixes for iris, Intel on x86 (32bit) and support compiling crocus on Android-x86

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,7 +30,7 @@ else
 # BOARD_GPU_DRIVERS should be defined.  The valid values are
 #
 #   classic drivers: i915 i965
-#   gallium drivers: swrast freedreno i915g nouveau kmsro r300g r600g radeonsi vc4 virgl vmwgfx etnaviv iris lima panfrost
+#   gallium drivers: swrast freedreno i915g nouveau kmsro r300g r600g radeonsi vc4 virgl vmwgfx etnaviv iris lima panfrost crocus
 #
 # The main target is libGLES_mesa.  For each classic driver enabled, a DRI
 # module will also be built.  DRI modules will be loaded by libGLES_mesa.
@@ -74,7 +74,8 @@ gallium_drivers := \
 	etnaviv.HAVE_GALLIUM_ETNAVIV \
 	iris.HAVE_GALLIUM_IRIS \
 	lima.HAVE_GALLIUM_LIMA \
-	panfrost.HAVE_GALLIUM_PANFROST
+	panfrost.HAVE_GALLIUM_PANFROST \
+	crocus.HAVE_GALLIUM_CROCUS
 
 ifeq ($(BOARD_GPU_DRIVERS),all)
 MESA_BUILD_CLASSIC := $(filter HAVE_%, $(subst ., , $(classic_drivers)))

--- a/android/Android.mk
+++ b/android/Android.mk
@@ -57,7 +57,7 @@ LOCAL_SHARED_LIBRARIES += libvulkan
 MESON_GEN_PKGCONFIGS += vulkan
 endif
 
-ifneq ($(filter iris,$(BOARD_MESA3D_GALLIUM_DRIVERS)),)
+ifneq ($(filter iris crocus,$(BOARD_MESA3D_GALLIUM_DRIVERS)),)
 LOCAL_SHARED_LIBRARIES += libdrm_intel
 MESON_GEN_PKGCONFIGS += libdrm_intel:$(LIBDRM_VERSION)
 endif

--- a/src/gallium/Android.mk
+++ b/src/gallium/Android.mk
@@ -48,6 +48,7 @@ SUBDIRS += winsys/svga/drm drivers/svga
 SUBDIRS += winsys/etnaviv/drm drivers/etnaviv drivers/renderonly
 SUBDIRS += frontends/dri
 SUBDIRS += winsys/iris/drm drivers/iris
+SUBDIRS += winsys/crocus/drm drivers/crocus
 SUBDIRS += winsys/lima/drm drivers/lima
 SUBDIRS += winsys/panfrost/drm drivers/panfrost
 

--- a/src/gallium/drivers/crocus/Android.mk
+++ b/src/gallium/drivers/crocus/Android.mk
@@ -187,23 +187,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libmesa_pipe_crocus
 LOCAL_MODULE_CLASS := STATIC_LIBRARIES
 
-intermediates := $(call local-generated-sources-dir)
-
-LOCAL_GENERATED_SOURCES := $(addprefix $(intermediates)/crocus/,$(GENERATED_SOURCES))
-
-GEN_DRIINFO_INPUTS := \
-        $(MESA_TOP)/src/gallium/auxiliary/pipe-loader/driinfo_gallium.h \
-        $(LOCAL_PATH)/driinfo_crocus.h
-
-MERGE_DRIINFO := $(MESA_TOP)/src/util/merge_driinfo.py
-
-$(intermediates)/crocus/crocus_driinfo.h: $(MERGE_DRIINFO) $(GEN_DRIINFO_INPUTS)
-	@mkdir -p $(dir $@)
-	@echo "Gen Header: $(PRIVATE_MODULE) <= $(notdir $(@))"
-	$(hide) $(MESA_PYTHON2) $(MERGE_DRIINFO) $(GEN_DRIINFO_INPUTS) > $@ || ($(RM) $@; false)
-
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(intermediates)
-
 LOCAL_SRC_FILES := \
 	$(CROCUS_C_SOURCES)
 

--- a/src/gallium/drivers/crocus/Android.mk
+++ b/src/gallium/drivers/crocus/Android.mk
@@ -29,6 +29,7 @@ include $(CLEAR_VARS)
 
 LIBCROCUS_SRC_FILES := \
 	crocus_blorp.c \
+	crocus_blt.c \
 	crocus_query.c \
 	crocus_state.c
 

--- a/src/gallium/drivers/crocus/Android.mk
+++ b/src/gallium/drivers/crocus/Android.mk
@@ -1,0 +1,243 @@
+# Mesa 3-D graphics library
+#
+# Copyright (C) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+LOCAL_PATH := $(call my-dir)
+
+# get C_SOURCES
+include $(LOCAL_PATH)/Makefile.sources
+
+include $(CLEAR_VARS)
+
+LIBCROCUS_SRC_FILES := \
+	crocus_blorp.c \
+	crocus_query.c \
+	crocus_state.c
+
+LIBCROCUS_STATIC_LIBS := \
+	libmesa_nir
+
+CROCUS_COMMON_INCLUDES := \
+	$(MESA_TOP)/src/mapi \
+	$(MESA_TOP)/src/mesa \
+	$(MESA_TOP)/src/gallium/include \
+	$(MESA_TOP)/src/gallium/auxiliary
+
+#
+# libcrocus for gen4
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen4
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=40
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen45
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen45
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=45
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen5
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen5
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=50
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen6
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen6
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=60
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen7
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen7
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=70
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen75
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen75
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=75
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+#
+# libcrocus for gen80
+#
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmesa_crocus_gen80
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+LOCAL_SRC_FILES := $(LIBCROCUS_SRC_FILES)
+LOCAL_CFLAGS := -DGFX_VERx10=80
+
+LOCAL_C_INCLUDES := $(CROCUS_COMMON_INCLUDES)
+
+LOCAL_STATIC_LIBRARIES := $(LIBCROCUS_STATIC_LIBS)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := libmesa_genxml
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+###########################################################
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libmesa_pipe_crocus
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+
+intermediates := $(call local-generated-sources-dir)
+
+LOCAL_GENERATED_SOURCES := $(addprefix $(intermediates)/crocus/,$(GENERATED_SOURCES))
+
+GEN_DRIINFO_INPUTS := \
+        $(MESA_TOP)/src/gallium/auxiliary/pipe-loader/driinfo_gallium.h \
+        $(LOCAL_PATH)/driinfo_crocus.h
+
+MERGE_DRIINFO := $(MESA_TOP)/src/util/merge_driinfo.py
+
+$(intermediates)/crocus/crocus_driinfo.h: $(MERGE_DRIINFO) $(GEN_DRIINFO_INPUTS)
+	@mkdir -p $(dir $@)
+	@echo "Gen Header: $(PRIVATE_MODULE) <= $(notdir $(@))"
+	$(hide) $(MESA_PYTHON2) $(MERGE_DRIINFO) $(GEN_DRIINFO_INPUTS) > $@ || ($(RM) $@; false)
+
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(intermediates)
+
+LOCAL_SRC_FILES := \
+	$(CROCUS_C_SOURCES)
+
+LOCAL_C_INCLUDES := \
+	$(MESA_TOP)/src/mapi \
+	$(MESA_TOP)/src/mesa \
+	$(MESA_TOP)/include/drm-uapi \
+	$(MESA_TOP)/src/gallium/include
+
+LOCAL_SHARED_LIBRARIES := libdrm_intel
+
+LOCAL_STATIC_LIBRARIES := \
+	libmesa_intel_common \
+	libmesa_nir
+
+LOCAL_WHOLE_STATIC_LIBRARIES := \
+	libmesa_genxml \
+	libmesa_blorp \
+	libmesa_intel_common \
+	libmesa_intel_compiler \
+	libmesa_intel_perf \
+	libmesa_crocus_gen4 \
+	libmesa_crocus_gen45 \
+	libmesa_crocus_gen5 \
+	libmesa_crocus_gen6 \
+	libmesa_crocus_gen7 \
+	libmesa_crocus_gen75 \
+	libmesa_crocus_gen80
+
+include $(GALLIUM_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)
+
+ifneq ($(HAVE_GALLIUM_CROCUS),)
+GALLIUM_TARGET_DRIVERS += crocus
+$(eval GALLIUM_LIBS += $(LOCAL_MODULE) libmesa_winsys_crocus)
+$(eval GALLIUM_SHARED_LIBS += $(LOCAL_SHARED_LIBRARIES))
+endif

--- a/src/gallium/drivers/crocus/Android.mk
+++ b/src/gallium/drivers/crocus/Android.mk
@@ -200,15 +200,14 @@ LOCAL_C_INCLUDES := \
 LOCAL_SHARED_LIBRARIES := libdrm_intel
 
 LOCAL_STATIC_LIBRARIES := \
-	libmesa_intel_common \
-	libmesa_nir
-
-LOCAL_WHOLE_STATIC_LIBRARIES := \
-	libmesa_genxml \
 	libmesa_blorp \
+	libmesa_genxml \
 	libmesa_intel_common \
 	libmesa_intel_compiler \
 	libmesa_intel_perf \
+	libmesa_nir
+
+LOCAL_WHOLE_STATIC_LIBRARIES := \
 	libmesa_crocus_gen4 \
 	libmesa_crocus_gen45 \
 	libmesa_crocus_gen5 \
@@ -222,6 +221,6 @@ include $(BUILD_STATIC_LIBRARY)
 
 ifneq ($(HAVE_GALLIUM_CROCUS),)
 GALLIUM_TARGET_DRIVERS += crocus
-$(eval GALLIUM_LIBS += $(LOCAL_MODULE) libmesa_winsys_crocus)
+$(eval GALLIUM_LIBS += $(LOCAL_MODULE) libmesa_winsys_crocus $(filter-out libmesa_nir, $(LOCAL_STATIC_LIBRARIES)))
 $(eval GALLIUM_SHARED_LIBS += $(LOCAL_SHARED_LIBRARIES))
 endif

--- a/src/gallium/drivers/crocus/Makefile.sources
+++ b/src/gallium/drivers/crocus/Makefile.sources
@@ -20,11 +20,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-GENERATED_SOURCES := \
-	crocus_driinfo.h
-
 CROCUS_C_SOURCES = \
-	$(GENERATED_SOURCES) \
 	driinfo_crocus.h \
 	crocus_batch.c \
 	crocus_batch.h \

--- a/src/gallium/drivers/crocus/Makefile.sources
+++ b/src/gallium/drivers/crocus/Makefile.sources
@@ -1,0 +1,56 @@
+# Mesa 3-D graphics library
+#
+# Copyright (C) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+GENERATED_SOURCES := \
+	crocus_driinfo.h
+
+CROCUS_C_SOURCES = \
+	$(GENERATED_SOURCES) \
+	driinfo_crocus.h \
+	crocus_batch.c \
+	crocus_batch.h \
+	crocus_blit.c \
+	crocus_bufmgr.c \
+	crocus_bufmgr.h \
+	crocus_clear.c \
+	crocus_context.c \
+	crocus_context.h \
+	crocus_disk_cache.c \
+	crocus_draw.c \
+	crocus_fence.c \
+	crocus_fence.h \
+	crocus_fine_fence.c \
+	crocus_fine_fence.h \
+	crocus_formats.c \
+	crocus_genx_macros.h \
+	crocus_genx_protos.h \
+	crocus_monitor.c \
+	crocus_pipe.h \
+	crocus_pipe_control.c \
+	crocus_program.c \
+	crocus_program_cache.c \
+	crocus_resolve.c \
+	crocus_resource.c \
+	crocus_resource.h \
+	crocus_screen.c \
+	crocus_screen.h \
+	gen4_blorp_exec.h

--- a/src/gallium/drivers/crocus/crocus_bufmgr.c
+++ b/src/gallium/drivers/crocus/crocus_bufmgr.c
@@ -1644,7 +1644,15 @@ crocus_bufmgr_create(struct intel_device_info *devinfo, int fd, bool bo_reuse)
    bufmgr->has_llc = devinfo->has_llc;
    bufmgr->has_tiling_uapi = devinfo->has_tiling_uapi;
    bufmgr->bo_reuse = bo_reuse;
+#if defined(ANDROID)
+   /* Android kernel still has some issues to support
+    * mmap_offset on 32 bit, hardcode to legacy mode
+    */
+   bufmgr->has_mmap_offset = false;
+#else
    bufmgr->has_mmap_offset = gem_param(fd, I915_PARAM_MMAP_GTT_VERSION) >= 4;
+#endif
+
 
    init_cache_buckets(bufmgr);
 

--- a/src/gallium/drivers/crocus/crocus_screen.c
+++ b/src/gallium/drivers/crocus/crocus_screen.c
@@ -846,8 +846,7 @@ crocus_screen_create(int fd, const struct pipe_screen_config *config)
    pscreen->flush_frontbuffer = crocus_flush_frontbuffer;
    pscreen->get_timestamp = crocus_get_timestamp;
    pscreen->query_memory_info = crocus_query_memory_info;
-   pscreen->get_driver_query_group_info = crocus_get_monitor_group_info;
-   pscreen->get_driver_query_info = crocus_get_monitor_info;
+
 
    genX_call(&screen->devinfo, crocus_init_screen_state, screen);
    genX_call(&screen->devinfo, crocus_init_screen_query, screen);

--- a/src/gallium/drivers/iris/Android.mk
+++ b/src/gallium/drivers/iris/Android.mk
@@ -158,15 +158,14 @@ LOCAL_C_INCLUDES := \
 LOCAL_SHARED_LIBRARIES := libdrm_intel
 
 LOCAL_STATIC_LIBRARIES := \
-	libmesa_intel_common \
-	libmesa_nir
-
-LOCAL_WHOLE_STATIC_LIBRARIES := \
-	libmesa_genxml \
 	libmesa_blorp \
+	libmesa_genxml \
 	libmesa_intel_common \
 	libmesa_intel_compiler \
 	libmesa_intel_perf \
+	libmesa_nir
+
+LOCAL_WHOLE_STATIC_LIBRARIES := \
 	libmesa_iris_gfx8 \
 	libmesa_iris_gfx9 \
 	libmesa_iris_gfx11 \
@@ -178,6 +177,6 @@ include $(BUILD_STATIC_LIBRARY)
 
 ifneq ($(HAVE_GALLIUM_IRIS),)
 GALLIUM_TARGET_DRIVERS += iris
-$(eval GALLIUM_LIBS += $(LOCAL_MODULE) libmesa_winsys_iris)
+$(eval GALLIUM_LIBS += $(LOCAL_MODULE) libmesa_winsys_iris $(filter-out libmesa_nir, $(LOCAL_STATIC_LIBRARIES)))
 $(eval GALLIUM_SHARED_LIBS += $(LOCAL_SHARED_LIBRARIES))
 endif

--- a/src/gallium/drivers/iris/iris_bufmgr.c
+++ b/src/gallium/drivers/iris/iris_bufmgr.c
@@ -1763,7 +1763,14 @@ iris_bufmgr_create(struct intel_device_info *devinfo, int fd, bool bo_reuse)
    bufmgr->has_llc = devinfo->has_llc;
    bufmgr->has_tiling_uapi = devinfo->has_tiling_uapi;
    bufmgr->bo_reuse = bo_reuse;
+#ifdef ANDROID
+   /* Android kernel still has some issues to support
+    * mmap_offset on 32 bit, hardcode to legacy mode
+    */
+   bufmgr->has_mmap_offset = false;
+#else
    bufmgr->has_mmap_offset = gem_param(fd, I915_PARAM_MMAP_GTT_VERSION) >= 4;
+#endif
    iris_bufmgr_query_meminfo(bufmgr);
 
    STATIC_ASSERT(IRIS_MEMZONE_SHADER_START == 0ull);

--- a/src/gallium/drivers/iris/iris_resource.c
+++ b/src/gallium/drivers/iris/iris_resource.c
@@ -570,7 +570,7 @@ want_ccs_e_for_format(const struct intel_device_info *devinfo,
 }
 
 static enum isl_surf_dim
-target_to_isl_surf_dim(enum pipe_texture_target target)
+iris_target_to_isl_surf_dim(enum pipe_texture_target target)
 {
    switch (target) {
    case PIPE_BUFFER:
@@ -652,7 +652,7 @@ iris_resource_configure_main(const struct iris_screen *screen,
       iris_format_for_usage(&screen->devinfo, templ->format, usage).fmt;
 
    const struct isl_surf_init_info init_info = {
-      .dim = target_to_isl_surf_dim(templ->target),
+      .dim = iris_target_to_isl_surf_dim(templ->target),
       .format = format,
       .width = templ->width0,
       .height = templ->height0,

--- a/src/gallium/drivers/iris/iris_screen.c
+++ b/src/gallium/drivers/iris/iris_screen.c
@@ -870,8 +870,6 @@ iris_screen_create(int fd, const struct pipe_screen_config *config)
    pscreen->flush_frontbuffer = iris_flush_frontbuffer;
    pscreen->get_timestamp = iris_get_timestamp;
    pscreen->query_memory_info = iris_query_memory_info;
-   pscreen->get_driver_query_group_info = iris_get_monitor_group_info;
-   pscreen->get_driver_query_info = iris_get_monitor_info;
 
    genX_call(&screen->devinfo, init_screen_state, screen);
 

--- a/src/gallium/winsys/crocus/drm/Android.mk
+++ b/src/gallium/winsys/crocus/drm/Android.mk
@@ -1,0 +1,40 @@
+# Mesa 3-D graphics library
+#
+# Copyright (C) 2018 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+LOCAL_PATH := $(call my-dir)
+
+# get C_SOURCES
+include $(LOCAL_PATH)/Makefile.sources
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := $(C_SOURCES)
+
+LOCAL_WHOLE_STATIC_LIBRARIES := \
+	libmesa_isl \
+	libmesa_intel_dev
+
+LOCAL_SHARED_LIBRARIES := libdrm_intel
+LOCAL_MODULE := libmesa_winsys_crocus
+
+include $(GALLIUM_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)

--- a/src/gallium/winsys/crocus/drm/Android.mk
+++ b/src/gallium/winsys/crocus/drm/Android.mk
@@ -29,7 +29,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := $(C_SOURCES)
 
-LOCAL_WHOLE_STATIC_LIBRARIES := \
+LOCAL_STATIC_LIBRARIES := \
 	libmesa_isl \
 	libmesa_intel_dev
 
@@ -38,3 +38,8 @@ LOCAL_MODULE := libmesa_winsys_crocus
 
 include $(GALLIUM_COMMON_MK)
 include $(BUILD_STATIC_LIBRARY)
+
+ifneq ($(HAVE_GALLIUM_CROCUS),)
+$(eval GALLIUM_LIBS += $(LOCAL_MODULE) $(LOCAL_STATIC_LIBRARIES))
+$(eval GALLIUM_SHARED_LIBS += $(LOCAL_SHARED_LIBRARIES))
+endif

--- a/src/gallium/winsys/crocus/drm/Makefile.sources
+++ b/src/gallium/winsys/crocus/drm/Makefile.sources
@@ -1,0 +1,3 @@
+C_SOURCES := \
+	crocus_drm_public.h \
+	crocus_drm_winsys.c

--- a/src/gallium/winsys/iris/drm/Android.mk
+++ b/src/gallium/winsys/iris/drm/Android.mk
@@ -29,7 +29,7 @@ include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := $(C_SOURCES)
 
-LOCAL_WHOLE_STATIC_LIBRARIES := \
+LOCAL_STATIC_LIBRARIES := \
 	libmesa_isl \
 	libmesa_intel_dev
 
@@ -38,3 +38,8 @@ LOCAL_MODULE := libmesa_winsys_iris
 
 include $(GALLIUM_COMMON_MK)
 include $(BUILD_STATIC_LIBRARY)
+
+ifneq ($(HAVE_GALLIUM_IRIS),)
+$(eval GALLIUM_LIBS += $(LOCAL_MODULE) $(LOCAL_STATIC_LIBRARIES))
+$(eval GALLIUM_SHARED_LIBS += $(LOCAL_SHARED_LIBRARIES))
+endif

--- a/src/intel/vulkan/anv_device.c
+++ b/src/intel/vulkan/anv_device.c
@@ -906,8 +906,12 @@ anv_physical_device_try_create(struct anv_instance *instance,
    device->always_flush_cache =
       driQueryOptionb(&instance->dri_options, "always_flush_cache");
 
+#ifdef ANDROID
+   device->has_mmap_offset = false;
+#else
    device->has_mmap_offset =
       anv_gem_get_param(fd, I915_PARAM_MMAP_GTT_VERSION) >= 4;
+#endif
 
    /* GENs prior to 8 do not support EU/Subslice info */
    device->subslice_total = intel_device_info_subslice_total(&device->info);

--- a/src/loader/Android.mk
+++ b/src/loader/Android.mk
@@ -1,0 +1,49 @@
+# Mesa 3-D graphics library
+#
+# Copyright (C) 2014 Emil Velikov <emil.l.velikov@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+LOCAL_PATH := $(call my-dir)
+
+include $(LOCAL_PATH)/Makefile.sources
+
+# ---------------------------------------
+# Build libmesa_loader
+# ---------------------------------------
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+	$(LOADER_C_FILES)
+
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)
+
+ifneq ($(HAVE_GALLIUM_IRIS),)
+LOCAL_CFLAGS += -DPREFER_IRIS
+endif
+
+ifneq ($(HAVE_GALLIUM_CROCUS),)
+LOCAL_CFLAGS += -DPREFER_CROCUS
+endif
+
+LOCAL_MODULE := libmesa_loader
+
+include $(MESA_COMMON_MK)
+include $(BUILD_STATIC_LIBRARY)

--- a/src/mesa/main/framebuffer.c
+++ b/src/mesa/main/framebuffer.c
@@ -826,9 +826,12 @@ _mesa_get_color_read_format(struct gl_context *ctx,
        * we will assume that on that situation the same error should be
        * triggered too.
        */
-      _mesa_error(ctx, GL_INVALID_OPERATION,
-                  "%s(GL_IMPLEMENTATION_COLOR_READ_FORMAT: no GL_READ_BUFFER)",
-                  caller);
+
+      /*
+	   * IMPLEMENTATION_COLOR_READ_FORMAT is for optimization purpose. if return
+	   * GL_NONE, just indicated there was no optimized additional format-type
+	   * can be used. So we decide to remove INVALID_OPERATION error generation.
+	   */
       return GL_NONE;
    }
    else {
@@ -901,9 +904,6 @@ _mesa_get_color_read_type(struct gl_context *ctx,
       /*
        * See comment on _mesa_get_color_read_format
        */
-      _mesa_error(ctx, GL_INVALID_OPERATION,
-                  "%s(GL_IMPLEMENTATION_COLOR_READ_TYPE: no GL_READ_BUFFER)",
-                  caller);
       return GL_NONE;
    }
    else {


### PR DESCRIPTION
Hi, these patches are for Intel iGPUs including :
- Fix Iris and ANV crash on x86 platform
- My attempt to support compiling crocus on Android-x86 source (32bit crash is fixed too, based on iris fix)
 
So far crocus is running great on nougat-x86 and pie-x86. Gallium HUD is working, I put the HUD variables into surfaceflinger.rc instead of the init script to run.
https://wiki.supreme-gamers.com/components/mesa/